### PR TITLE
Enhanced watchmode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 /*.o
 /virus
 /ee
+/*.swp

--- a/config.l
+++ b/config.l
@@ -76,6 +76,7 @@ cursor		{ return TYPE_CURSOR; }
 "short_name"	{ return TYPE_GAME_SHORT_NAME; }
 "game_id"	{ return TYPE_GAME_ID; }
 "game_path"	{ return TYPE_PATH_GAME; }
+"watch_path"	{ return TYPE_PATH_WATCH; }
 "dglroot"	{ return TYPE_PATH_DGLDIR; }
 "spooldir"	{ return TYPE_PATH_SPOOL; }
 "banner"	{ return TYPE_PATH_BANNER; }
@@ -84,6 +85,7 @@ cursor		{ return TYPE_CURSOR; }
 "lockfile"	{ return TYPE_PATH_LOCKFILE; }
 "inprogressdir" { return TYPE_PATH_INPROGRESS; }
 "game_args"	{ return TYPE_GAME_ARGS; }
+"watch_args"	{ return TYPE_WATCH_ARGS; }
 extra_info_file { return TYPE_EXTRA_INFO_FILE; }
 "max_idle_time"	{ return TYPE_MAX_IDLE_TIME; }
 "rc_fmt"	{ return TYPE_RC_FMT; }
@@ -94,6 +96,7 @@ sortmode	{ return TYPE_WATCH_SORTMODE; }
 watch_columns	{ return TYPE_WATCH_COLUMNS; }
 commands	{ return TYPE_CMDQUEUE; }
 postcommands	{ return TYPE_POSTCMDQUEUE; }
+watchcommands	{ return TYPE_WATCHCMDQUEUE; }
 encoding	{ return TYPE_ENCODING; }
 locale		{ return TYPE_LOCALE; }
 default_term	{ return TYPE_DEFTERM; }

--- a/dgamelaunch.c
+++ b/dgamelaunch.c
@@ -950,7 +950,7 @@ game_get_column_data(struct dg_game *game,
 
     case SORTMODE_WINDOWSIZE:
         if (myconfig[game->gamenum]->watch_path) {
-            snprintf(data, bufsz, "N/A");
+            snprintf(data, bufsz, "  N/A");
             *hilite = CLR_GREEN;
             break;
         }

--- a/dgamelaunch.c
+++ b/dgamelaunch.c
@@ -949,6 +949,11 @@ game_get_column_data(struct dg_game *game,
         break;
 
     case SORTMODE_WINDOWSIZE:
+        if (myconfig[game->gamenum]->watch_path) {
+            snprintf(data, bufsz, "N/A");
+            *hilite = CLR_GREEN;
+            break;
+        }
         snprintf(data, bufsz, "%3dx%3d", game->ws_col, game->ws_row);
 	if (showplayers)
 		snprintf(data, bufsz, "%dx%d", game->ws_col, game->ws_row);
@@ -1039,7 +1044,7 @@ inprogressmenu (int gameid)
 
   shm_init(&shm_dg_data, &shm_dg_game);
 
-  games = populate_games (gameid, &len, NULL); /* FIXME: should be 'me' instead of 'NULL' */
+  games = populate_games (gameid, &len, me);
   shm_update(shm_dg_data, games, len);
   games = sort_games (games, len, sortmode);
 
@@ -1274,7 +1279,49 @@ watchgame:
 		  setproctitle("%s [watching %s]", me->username, chosen_name);
 	      else
 		  setproctitle("<Anonymous> [watching %s]", chosen_name);
-              ttyplay_main (ttyrecname, 1, resizex, resizey);
+              if (myconfig[games[idx]->gamenum]->watch_path) {
+                  pid_t child;
+                  int gnum = games[idx]->gamenum;
+                  char **wargs = (char **)malloc(sizeof(char *) * (myconfig[gnum]->num_wargs+1));
+                  dgl_exec_cmdqueue_w(myconfig[gnum]->watchcmdqueue, gnum, me, chosen_name);
+                  /* fix the variables in the arguments */
+                  for (i = 0; i < myconfig[gnum]->num_wargs; i++) {
+                      wargs[i] = strdup(dgl_format_str(gnum, me, myconfig[gnum]->watch_args[i], chosen_name));
+                  }
+                  wargs[myconfig[gnum]->num_wargs] = NULL;
+                  /* tidy up signals before launching external process */
+                  signal(SIGWINCH, SIG_DFL);
+                  signal(SIGINT, SIG_DFL);
+                  signal(SIGQUIT, SIG_DFL);
+                  signal(SIGTERM, SIG_DFL);
+                  idle_alarm_set_enabled(0);
+                  /* launch program */
+                  child = fork();
+                  if (child < 0) {
+                      perror ("fork");
+                      fail ();
+                  }
+                  if (child == 0) {
+                      execvp (myconfig[gnum]->watch_path, wargs);
+                  } else {
+                      int status;
+                      (void) wait(&status);
+                  }
+                  /* reset signals on return */
+                  idle_alarm_set_enabled(1);
+                  signal(SIGHUP, catch_sighup);
+                  signal(SIGINT, catch_sighup);
+                  signal(SIGQUIT, catch_sighup);
+                  signal(SIGTERM, catch_sighup);
+                  signal(SIGWINCH, sigwinch_func);
+                  /* free temporary watch args */
+                  for (i = 0; i < myconfig[gnum]->num_wargs; i++) {
+                      free(wargs[i]);
+                  }
+                  free(wargs);
+              } else {
+                  ttyplay_main (ttyrecname, 1, resizex, resizey);
+              }
 	      if (loggedin)
 		  setproctitle("%s", me->username);
 	      else
@@ -1302,7 +1349,7 @@ watchgame:
 
       if (selected >= 0 && selected < len)
 	  selectedgame = strdup(games[selected]->name);
-      games = populate_games (gameid, &len, NULL); /* FIXME: should be 'me' instead of 'NULL' */
+      games = populate_games (gameid, &len, me);
       shm_update(shm_dg_data, games, len);
       games = sort_games (games, len, sortmode);
       if (selectedgame) {
@@ -1345,7 +1392,7 @@ inprogressdisplay (int gameid)
 
   shm_init(&shm_dg_data, &shm_dg_game);
 
-  games = populate_games (gameid, &len, NULL); /* FIXME: should be 'me' instead of 'NULL' */
+  games = populate_games (gameid, &len, me);
   shm_update(shm_dg_data, games, len);
   games = sort_games (games, len, sortmode);
 

--- a/dgamelaunch.h
+++ b/dgamelaunch.h
@@ -30,9 +30,11 @@
 #ifdef USE_NCURSES_COLOR
 # define CLR_NORMAL  COLOR_PAIR(11)   | A_NORMAL
 # define CLR_RED     COLOR_PAIR(COLOR_RED)   | A_NORMAL
+# define CLR_GREEN   COLOR_PAIR(COLOR_GREEN) | A_NORMAL
 #else
 # define CLR_NORMAL  0
 # define CLR_RED     0
+# define CLR_GREEN   0
 #endif
 extern int color_remap[];
 
@@ -198,6 +200,7 @@ struct dg_game
 struct dg_config
 {
   char* game_path;
+  char* watch_path;
   char* game_name;
   char* game_id;
   char* shortname;
@@ -206,10 +209,13 @@ struct dg_config
   char* spool;
   char* inprogressdir;
     int num_args; /* # of bin_args */
+    int num_wargs; /* # of watch_args */
     char **bin_args; /* args for game binary */
+    char **watch_args; /* args for watch binary */
     char *rc_fmt;
     struct dg_cmdpart *cmdqueue;
     struct dg_cmdpart *postcmdqueue;
+    struct dg_cmdpart *watchcmdqueue;
     int max_idle_time;
     char *extra_info_file;
     int encoding; // -1 = run --print-charset
@@ -301,6 +307,7 @@ extern void sigwinch_func(int sig);
 extern struct dg_menu *dgl_find_menu(char *menuname);
 
 extern int dgl_exec_cmdqueue(struct dg_cmdpart *queue, int game, struct dg_user *me);
+extern int dgl_exec_cmdqueue_w(struct dg_cmdpart *queue, int game, struct dg_user *me, char *playername);
 
 extern void free_populated_games(struct dg_game **games, int len);
 extern struct dg_game **populate_games(int game, int *l, struct dg_user *me);

--- a/examples/dgamelaunch.conf
+++ b/examples/dgamelaunch.conf
@@ -153,8 +153,10 @@ default_term = "xterm"
 # defined above.
 # Parameters to the commands are subject to variable substitution:
 #   %r = dglroot, as defined above
-#   %n = user nick, if user is logged in
-#   %N = first character of user name, if user is logged in
+#   %n = user nick, if user is logged in, or user being watched.
+#   %l = user nick, if logged in, otherwise empty string.
+#   %w = user selected from the watch menu (or logged in user if no user selected)
+#   %N, %L, %W = first character of the above
 #   %u = shed_uid, as defined above, but numeric
 #   %g = game name, if user has selected a game.
 #   %s = short game name, if user has selected a game.
@@ -310,6 +312,59 @@ menu["watchmenu_help"] {
 #  encoding = "unicode"
 #}
 
+#
+# fiqhack example - showing watch mode options
+#
+#
+
+#DEFINE {
+#  game_path = "/fiqhackdir/fiqhack"
+#  game_name = "FIQHack 4.3.0"
+#  short_name = "fiqhack"
+#
+#  game_args = "/fiqhackdir/fiqhack",
+#              "-H", "/fiqhackdir/data",
+#              "-U", "%ruserdata/%N/%n/fiqhack"
+#
+#  spooldir = "/mail/"
+#  #rc_template = "/dgl-default-rcfile.gh"
+#
+#  #rc_fmt = "%ruserdata/%N/%n/%n.ghrc"
+#
+#  inprogressdir = "%rinprogress-fh/"
+#  extra_info_file = "%rextrainfo-fh/%n.extrainfo"
+#
+#  # The place where ttyrecs are stored for this game.
+#  # If this is not defined, ttyrecs are not saved for this game.
+#  # ttyrecs are not necessary for spectating if watch_path is configured.
+#  ttyrecdir = "%ruserdata/%N/%n/ttyrec/"
+#
+#
+#  commands = setenv "NH4SERVERUSER" "%n",
+#             setenv "NHMAILBOX" "/mail/%n",
+#             setenv "SIMPLEMAIL" "1",
+#             unlink "/mail/%n"
+#
+#  # The executable to use for watching instead of the built-in ttyrec player
+#  watch_path = "/fiqhackdir/fiqhack"
+#
+#  # The args to call it with. As with game_args, argv[0] needs to be included
+#  watch_args = "/fiqhackdir/fiqhack",
+#               "-H", "/fiqhackdir/data",
+#               # we use %n here so anonymous viewers can inherit the config
+#               # of the player. The watch program needs to ensure the watcher
+#               # can't modify anything in here that would affect the player.
+#               "-U", "%ruserdata/%N/%n/fiqhack",
+#               # %w is the player to watch
+#               "-W", "%ruserdata/%W/%w/fiqhack"
+#
+#  # these are run before watching commences.
+#  # Use %l so the watching program knows if the watcher is logged in.
+#  # The watching program should disable mail for anonymous watchers.
+#  watchcommands = setenv "NH4SERVERUSER" "%w",
+#                  setenv "NH4WATCHER" "%l",
+#                  setenv "NHMAILBOX" "/mail/%w"
+#}
 
 #
 # the second game


### PR DESCRIPTION
Allow an external program to be specified to watch particular games
to make use of NH4's wachmode. Add game config options watch_path,
watch_args and watchcommands to support this.  Also add %w/%W for
format tokens the watched player, and %l/%L for the logged-in user
because %n/%N fall back to the watched player if nobody is logged
in, which is not always what we want.  Watch menu now displays N/A
for the terminal size of games which use this, because NH4 watch
mode does not care about player's terminal dimensions.  Other external
watching tools may need this in the future, but for now there is
nothing that requires this.